### PR TITLE
Added support for reading com.apple.xray.instrument-type.homeleaks instrument

### DIFF
--- a/TraceUtility/InstrumentsPrivateHeader.h
+++ b/TraceUtility/InstrumentsPrivateHeader.h
@@ -288,3 +288,27 @@ BOOL XRAnalysisCoreReadCursorGetValue(XRAnalysisCoreReadCursor *cursor, UInt8 co
 }
 - (NSArray<XRContext *> *)_topLevelContexts;
 @end
+
+// MARK: - Memory leaks
+
+@interface XRLeaksRun : XRRun
+- (NSArray *)allLeaks;
+@end
+
+@interface DVT_VMUClassInfo : NSObject
+- (NSString *)remoteClassName;
+- (NSString *)genericInfo;
+- (UInt32)instanceSize;
+@end
+
+@interface XRLeak : NSObject
+- (NSString *) name;
+- (unsigned long) size;
+- (unsigned long) count;
+- (BOOL) inCycle;
+- (BOOL) isRootLeak;
+- (unsigned long long) allocationTimestamp;
+- (NSString *) displayAddress;
+- (DVT_VMUClassInfo *) classInfo;
+- (DVT_VMUClassInfo *) _layout;
+@end

--- a/TraceUtility/main.m
+++ b/TraceUtility/main.m
@@ -215,6 +215,26 @@ int main(int argc, const char * argv[]) {
                             }];
                         }];
                     }
+                } else if ([instrumentID isEqualToString:@"com.apple.xray.instrument-type.homeleaks"]) {
+
+                    XRLeaksRun *leaksRun = (XRLeaksRun *)run;
+                    for (XRLeak *leak in leaksRun.allLeaks) {
+                        DVT_VMUClassInfo *dvt = TUIvar(leak, _layout);
+                        NSDictionary *parsedLeak = @{
+                            @"name": leak.name != nil ? leak.name : @"",
+                            @"description": dvt != nil && dvt.description ? dvt.description : @"",
+                            @"size": @(leak.size),
+                            @"count": @(leak.count),
+                            @"isCycle": @(leak.inCycle),
+                            @"isRootLeak": @(leak.isRootLeak),
+                            @"allocationTimestamp": @(leak.allocationTimestamp),
+                            @"displayAddress": leak.displayAddress != nil ? leak.displayAddress : @"",
+                            @"debugDescription": dvt != nil && dvt.debugDescription ? dvt.debugDescription : @"",
+                        };
+                        NSString *name = dvt != nil && dvt.description ? dvt.description : parsedLeak[@"name"];
+                        TUPrint(@"Leaked %@x times: %@", parsedLeak[@"count"], name);
+                    }
+
                 } else {
                     TUPrint(@"Data processor has not been implemented for this type of instrument.\n");
                 }


### PR DESCRIPTION
# What changed:

- Adds `XRLeak`, `XRLeaksRun`, `DVT_VMUClassInfo` types 
  used in `com.apple.xray.instrument-type.homeleaks` instrument
- Creates `NSDictionary *parsedLeak` with some useful memory leak properties.

# How to test:

- Download [trace file](https://github.com/Qusic/TraceUtility/files/2898273/Example.trace.zip) containing memory leaks
- Build binary of `TraceUtility`
- Running `./TraceUtility Example.trace` should output:

```
Instrument: Leaks (com.apple.xray.instrument-type.homeleaks)
Run #1: Run 1
Leaked 1x times: Malloc 48 Bytes
Leaked 1x times: Malloc 48 Bytes
Leaked 1x times: Malloc 48 Bytes
Leaked 1x times: Malloc 48 Bytes
Leaked 1x times: Malloc 32 Bytes
Leaked 1x times: Malloc 32 Bytes
Leaked 1x times: Malloc 32 Bytes
Leaked 1x times: Malloc 32 Bytes
Leaked 1x times: Generator  Swift  Leakmax
Leaked 1x times: Generator  Swift  Leakmax
Leaked 1x times: CFDictionary  ObjC  CoreFoundation
Leaked 1x times: CFDictionary  ObjC  CoreFoundation
Leaked 1x times: UINavigationItem  ObjC  UIKitCore
Leaked 1x times: UITabBarItem  ObjC  UIKitCore
Leaked 1x times: UINavigationItem  ObjC  UIKitCore
Leaked 1x times: UITabBarItem  ObjC  UIKitCore
Leaked 1x times: GeneratorViewController  Swift  Leakmax
Leaked 1x times: GeneratorViewController  Swift  Leakmax
```

